### PR TITLE
Add OpenAI chat endpoint and basic React UI

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -2,4 +2,7 @@ module backend
 
 go 1.19
 
-require github.com/rs/cors v1.8.3
+require (
+	github.com/rs/cors v1.8.3
+	github.com/sashabaranov/go-openai v1.40.5
+)

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -1,2 +1,4 @@
 github.com/rs/cors v1.8.3 h1:O+qNyWn7Z+F9M0ILBHgMVPuB1xTOucVd5gtaYyXBpRo=
 github.com/rs/cors v1.8.3/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
+github.com/sashabaranov/go-openai v1.40.5 h1:SwIlNdWflzR1Rxd1gv3pUg6pwPc6cQ2uMoHs8ai+/NY=
+github.com/sashabaranov/go-openai v1.40.5/go.mod h1:lj5b/K+zjTSFxVLijLSTDZuP7adOgerWeFyZLUhAKRg=

--- a/backend/openai_client.go
+++ b/backend/openai_client.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"context"
+	"os"
+
+	openai "github.com/sashabaranov/go-openai"
+)
+
+type OpenAIClient struct {
+	client *openai.Client
+}
+
+func NewOpenAIClient() *OpenAIClient {
+	apiKey := os.Getenv("OPENAI_API_KEY")
+	c := openai.NewClient(apiKey)
+	return &OpenAIClient{client: c}
+}
+
+func (o *OpenAIClient) Chat(prompt, model string) (string, error) {
+	req := openai.ChatCompletionRequest{
+		Model: model,
+		Messages: []openai.ChatCompletionMessage{
+			{Role: openai.ChatMessageRoleUser, Content: prompt},
+		},
+	}
+	resp, err := o.client.CreateChatCompletion(context.Background(), req)
+	if err != nil {
+		return "", err
+	}
+	if len(resp.Choices) == 0 {
+		return "", nil
+	}
+	return resp.Choices[0].Message.Content, nil
+}

--- a/backend/server.go
+++ b/backend/server.go
@@ -27,13 +27,15 @@ func (m *ApiNewMessage) ToConversationMessage() conversation.Message {
 type ChatServer struct {
 	conversation *conversation.Conversation
 	imageStorage *imageServer.ImageStorage
+	openai       *OpenAIClient
 }
 
 func newChatServer() ChatServer {
 	c := conversation.NewConversation()
 	i := imageServer.NewImageStorage()
+	o := NewOpenAIClient()
 
-	return ChatServer{conversation: &c, imageStorage: &i}
+	return ChatServer{conversation: &c, imageStorage: &i, openai: o}
 }
 
 func (s *ChatServer) GetMessages(w http.ResponseWriter, r *http.Request) {
@@ -66,6 +68,25 @@ func (s *ChatServer) writeMessage(w http.ResponseWriter, r *http.Request) {
 
 func (s *ChatServer) deleteAllMessages(w http.ResponseWriter, r *http.Request) {
 	s.conversation.DeleteAllMessages()
+}
+
+type openAIRequest struct {
+	Prompt string `json:"prompt"`
+	Model  string `json:"model"`
+}
+
+func (s *ChatServer) openaiChat(w http.ResponseWriter, r *http.Request) {
+	var body openAIRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	resp, err := s.openai.Chat(body.Prompt, body.Model)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	json.NewEncoder(w).Encode(map[string]string{"response": resp})
 }
 
 // Handler that retrieves images from a directory and returns an array of images
@@ -101,11 +122,13 @@ func StartServer(port string) {
 	chatServer := newChatServer()
 
 	mux := http.NewServeMux()
-	mux.HandleFunc("/getMessages", chatServer.conversation.GetMessages)
+	mux.HandleFunc("/getMessages", chatServer.GetMessages)
 	mux.HandleFunc("/write", chatServer.writeMessage)
 	mux.HandleFunc("/deleteAllMessages", chatServer.deleteAllMessages)
 
-	mux.HandleFunc("/getImage", chatServer.GetImage)
+	mux.HandleFunc("/openai/chat", chatServer.openaiChat)
+
+	mux.HandleFunc("/getImage", GetImage)
 
 	handler := cors.AllowAll().Handler(logRequest(mux))
 	server := &http.Server{

--- a/frontend/client/src/OpenAIPage.js
+++ b/frontend/client/src/OpenAIPage.js
@@ -1,0 +1,38 @@
+import {useState} from 'react';
+import {apiOpenAIChat} from './api';
+
+const OpenAIPage = () => {
+    const [model, setModel] = useState('gpt-3.5-turbo');
+    const [prompt, setPrompt] = useState('');
+    const [response, setResponse] = useState('');
+
+    const handleSend = async () => {
+        const res = await apiOpenAIChat(prompt, model);
+        if (res && res.response) {
+            setResponse(res.response);
+        } else {
+            setResponse('');
+        }
+    };
+
+    return (
+        <div className='container-col'>
+            <h2>OpenAI Chat</h2>
+            <select value={model} onChange={(e)=>setModel(e.target.value)}>
+                <option value='gpt-3.5-turbo'>gpt-3.5-turbo</option>
+                <option value='gpt-4'>gpt-4</option>
+            </select>
+            <textarea
+                rows={5}
+                value={prompt}
+                onChange={(e)=>setPrompt(e.target.value)}
+                className='input-text bg-mid mg-top-md'
+                placeholder='Escribe tu pregunta'
+            />
+            <button className='btn mg-top-md' onClick={handleSend}>Enviar</button>
+            <pre className='mg-top-md'>{response}</pre>
+        </div>
+    );
+};
+
+export default OpenAIPage;

--- a/frontend/client/src/api.js
+++ b/frontend/client/src/api.js
@@ -4,6 +4,7 @@ const SERVER_ADDR = 'http://localhost:2000/';
 const GET_MESSAGES_API = SERVER_ADDR + 'getMessages';
 const WRITE_MESSAGE_API = SERVER_ADDR + 'write';
 const DELETE_ALL_MESSAGES_API = SERVER_ADDR + 'deleteAllMessages';
+const OPENAI_CHAT_API = SERVER_ADDR + 'openai/chat';
 
 const apiGetMessages = async () => {
     const response = await fetch(GET_MESSAGES_API);
@@ -28,4 +29,13 @@ const apiWriteMessage = async (author, to, message) => {
     await axios.post(WRITE_MESSAGE_API, body, options);
 }
 
-export {apiGetMessages, apiDeleteAllMessages, apiWriteMessage}
+const apiOpenAIChat = async (prompt, model) => {
+    const response = await fetch(OPENAI_CHAT_API, {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({prompt: prompt, model: model})
+    });
+    return await response.json();
+}
+
+export {apiGetMessages, apiDeleteAllMessages, apiWriteMessage, apiOpenAIChat}

--- a/frontend/client/src/index.js
+++ b/frontend/client/src/index.js
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 import {createBrowserRouter, RouterProvider} from "react-router-dom";
 import App from "./App";
+import OpenAIPage from "./OpenAIPage";
 
 const router = createBrowserRouter([
     {
@@ -12,6 +13,10 @@ const router = createBrowserRouter([
     {
         path: "/admin",
         element: <App isAdmin={true} />,
+    },
+    {
+        path: "/openai",
+        element: <OpenAIPage />,
     },
 ]);
 


### PR DESCRIPTION
## Summary
- create OpenAI client in backend
- expose `/openai/chat` API endpoint
- add minimal React page for chatting with OpenAI and choose model
- add API wrapper for new endpoint and route to new page

## Testing
- `go build ./...`
- `npm test --silent -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_688cd09e61f8832baea3473212b53591